### PR TITLE
Fix to support Windows

### DIFF
--- a/src/main/groovy/com/kiefer/gradle/EmberCliPlugin.groovy
+++ b/src/main/groovy/com/kiefer/gradle/EmberCliPlugin.groovy
@@ -1,8 +1,11 @@
 package com.kiefer.gradle
+
+import com.sun.org.apache.xpath.internal.operations.Bool
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.tasks.Exec
 import org.gradle.api.tasks.TaskInputs
+import org.apache.tools.ant.taskdefs.condition.Os
 
 class EmberCliPlugin implements Plugin<Project> {
     @Override
@@ -56,7 +59,12 @@ class EmberCliPlugin implements Plugin<Project> {
                     outputs.file "node_modules"
                 }
 
-                executable 'npm'
+                if(isWindows()) {
+                    executable 'cmd'
+                    args '/c', 'npm'
+                } else {
+                    executable 'npm'
+                }
 
                 if (project.embercli.npmRegistry) {
                     args '--registry', project.embercli.npmRegistry, 'install'
@@ -78,7 +86,13 @@ class EmberCliPlugin implements Plugin<Project> {
                     outputs.file "bower_components"
                 }
 
-                executable findProgram(project, "bower")
+                if(isWindows()) {
+                    executable 'cmd'
+                    args '/c', findProgram(project, "bower")
+                } else {
+                    executable findProgram(project, "bower")
+                }
+
                 args 'install'
             }
 
@@ -95,7 +109,12 @@ class EmberCliPlugin implements Plugin<Project> {
                     outputs.file "bower_components"
                 }
 
-                executable findProgram(project, "bower")
+                if(isWindows()) {
+                    executable 'cmd'
+                    args '/c', findProgram(project, "bower")
+                } else {
+                    executable findProgram(project, "bower")
+                }
                 args 'update'
             }
 
@@ -117,7 +136,12 @@ class EmberCliPlugin implements Plugin<Project> {
                     new File(project.projectDir, "dist").exists()
                 }
 
-                executable findProgram(project, "ember")
+                if(isWindows()) {
+                    executable 'cmd'
+                    args '/c', findProgram(project, "ember")
+                } else {
+                    executable findProgram(project, "ember")
+                }
 
                 args 'test', '--test-port=-1'
             }
@@ -130,11 +154,21 @@ class EmberCliPlugin implements Plugin<Project> {
                 outputs.dir "dist"
 
                 dependsOn 'npmInstall', 'bowerInstall', 'bowerUpdate', 'test'
-                executable findProgram(project, "ember")
+
+                if(isWindows()) {
+                    executable 'cmd'
+                    args '/c', findProgram(project, "ember")
+                } else {
+                    executable findProgram(project, "ember")
+                }
 
                 args "build", "--environment", project.embercli.environment
             }
         }
+    }
+
+    private static Boolean isWindows() {
+        return Os.isFamily(Os.FAMILY_WINDOWS);
     }
 
     private static String findProgram(project, String program) {

--- a/src/test/groovy/com/kiefer/gradle/BowerInstallTask.groovy
+++ b/src/test/groovy/com/kiefer/gradle/BowerInstallTask.groovy
@@ -1,5 +1,6 @@
 package com.kiefer.gradle
 
+import org.apache.tools.ant.taskdefs.condition.Os
 import org.testng.annotations.Test
 
 class BowerInstallTask extends EmberCliPluginSupport {
@@ -18,8 +19,16 @@ class BowerInstallTask extends EmberCliPluginSupport {
     void taskExecutesAppropriateCommand() {
         def task = project.tasks.bowerInstall
         assert project.rootDir == task.workingDir
-        assert task.executable.contains("bower")
-        assert ["install"] == task.args
+        if(Os.isFamily(Os.FAMILY_WINDOWS)) {
+            assert "cmd" == task.executable
+            assert task.args.size() == 3
+            assert task.args.contains("/c")
+            assert task.args.contains("bower")
+            assert task.args.contains("install")
+        } else {
+            assert task.executable.contains("bower")
+            assert ["install"] == task.args
+        }
     }
 
     @Test

--- a/src/test/groovy/com/kiefer/gradle/BowerUpdateTask.groovy
+++ b/src/test/groovy/com/kiefer/gradle/BowerUpdateTask.groovy
@@ -1,5 +1,6 @@
 package com.kiefer.gradle
 
+import org.apache.tools.ant.taskdefs.condition.Os
 import org.testng.annotations.Test
 
 class BowerUpdateTask extends EmberCliPluginSupport {
@@ -19,8 +20,16 @@ class BowerUpdateTask extends EmberCliPluginSupport {
     void taskExecutesAppropriateCommand() {
         def task = project.tasks.bowerUpdate
         assert project.rootDir == task.workingDir
-        assert task.executable.contains("bower")
-        assert ["update"] == task.args
+        if(Os.isFamily(Os.FAMILY_WINDOWS)) {
+            assert "cmd" == task.executable
+            assert task.args.size() == 3
+            assert task.args.contains("/c")
+            assert task.args.contains("bower")
+            assert task.args.contains("update")
+        } else {
+            assert task.executable.contains("bower")
+            assert ["update"] == task.args
+        }
     }
 
     @Test

--- a/src/test/groovy/com/kiefer/gradle/EmberBuildConfigurationTest.groovy
+++ b/src/test/groovy/com/kiefer/gradle/EmberBuildConfigurationTest.groovy
@@ -1,5 +1,6 @@
 package com.kiefer.gradle
 
+import org.apache.tools.ant.taskdefs.condition.Os
 import org.gradle.testfixtures.ProjectBuilder
 import org.testng.annotations.BeforeMethod
 import org.testng.annotations.Test
@@ -23,7 +24,17 @@ class EmberBuildConfigurationTest extends EmberCliPluginSupport {
     void taskExecutesAppropriateCommand() {
         def task = project.tasks.emberBuild
         assert project.rootDir == task.workingDir
-        assert task.executable.contains("ember")
-        assert ["build", "--environment", "development"] == task.args
+        if(Os.isFamily(Os.FAMILY_WINDOWS)) {
+            assert "cmd" == task.executable
+            assert task.args.size() == 5
+            assert task.args.contains("/c")
+            assert task.args.contains("ember")
+            assert task.args.contains("build")
+            assert task.args.contains("--environment")
+            assert task.args.contains("development")
+        } else {
+            assert task.executable.contains("ember")
+            assert ["build", "--environment", "development"] == task.args
+        }
     }
 }

--- a/src/test/groovy/com/kiefer/gradle/EmberBuildTaskTest.groovy
+++ b/src/test/groovy/com/kiefer/gradle/EmberBuildTaskTest.groovy
@@ -1,5 +1,6 @@
 package com.kiefer.gradle
 
+import org.apache.tools.ant.taskdefs.condition.Os
 import org.testng.annotations.Test
 
 class EmberBuildTaskTest extends EmberCliPluginSupport {
@@ -13,8 +14,18 @@ class EmberBuildTaskTest extends EmberCliPluginSupport {
     void taskExecutesAppropriateCommand() {
         def task = project.tasks.emberBuild
         assert project.rootDir == task.workingDir
-        assert task.executable.contains("ember")
-        assert ["build", "--environment", "production"] == task.args
+        if(Os.isFamily(Os.FAMILY_WINDOWS)) {
+            assert "cmd" == task.executable
+            assert task.args.size() == 5
+            assert task.args.contains("/c")
+            assert task.args.contains("ember")
+            assert task.args.contains("build")
+            assert task.args.contains("--environment")
+            assert task.args.contains("production")
+        } else {
+            assert task.executable.contains("ember")
+            assert ["build", "--environment", "production"] == task.args
+        }
     }
 
     @Test

--- a/src/test/groovy/com/kiefer/gradle/NpmInstallConfigurationTest.groovy
+++ b/src/test/groovy/com/kiefer/gradle/NpmInstallConfigurationTest.groovy
@@ -1,5 +1,6 @@
 package com.kiefer.gradle
 
+import org.apache.tools.ant.taskdefs.condition.Os
 import org.gradle.testfixtures.ProjectBuilder
 import org.testng.annotations.BeforeMethod
 import org.testng.annotations.Test
@@ -24,7 +25,11 @@ class NpmInstallConfigurationTest extends EmberCliPluginSupport {
     @Test
     void taskExecutesAppropriateCommand() {
         def task = project.tasks.npmInstall
-        assert ["--registry", "foo", "install"] == task.args
+        if(Os.isFamily(Os.FAMILY_WINDOWS)) {
+            assert ["/c", "npm", "--registry", "foo", "install"] == task.args
+        } else {
+            assert ["--registry", "foo", "install"] == task.args
+        }
     }
 
     @Test

--- a/src/test/groovy/com/kiefer/gradle/NpmInstallTask.groovy
+++ b/src/test/groovy/com/kiefer/gradle/NpmInstallTask.groovy
@@ -1,5 +1,6 @@
 package com.kiefer.gradle
 
+import org.apache.tools.ant.taskdefs.condition.Os
 import org.testng.annotations.Test
 
 class NpmInstallTask extends EmberCliPluginSupport {
@@ -13,8 +14,13 @@ class NpmInstallTask extends EmberCliPluginSupport {
     void taskExecutesAppropriateCommand() {
         def task = project.tasks.npmInstall
         assert project.rootDir == task.workingDir
-        assert "npm" == task.executable
-        assert ["install"] == task.args
+        if(Os.isFamily(Os.FAMILY_WINDOWS)) {
+            assert "cmd" == task.executable
+            assert ["/c", "npm", "install"] == task.args
+        } else {
+            assert "npm" == task.executable
+            assert ["install"] == task.args
+        }
     }
 
     @Test

--- a/src/test/groovy/com/kiefer/gradle/TestTaskTest.groovy
+++ b/src/test/groovy/com/kiefer/gradle/TestTaskTest.groovy
@@ -1,5 +1,6 @@
 package com.kiefer.gradle
 
+import org.apache.tools.ant.taskdefs.condition.Os
 import org.testng.annotations.Test
 
 class TestTaskTest extends EmberCliPluginSupport {
@@ -11,10 +12,19 @@ class TestTaskTest extends EmberCliPluginSupport {
     @Test
     void taskExecutesAppropriateCommand() {
         def task = project.tasks.test
-        assert task.executable.contains("ember")
-        assert task.args.size() == 2
-        assert task.args.contains("test")
-        assert task.args.contains("--test-port=-1")
+        if(Os.isFamily(Os.FAMILY_WINDOWS)) {
+            assert "cmd" == task.executable
+            assert task.args.size() == 4
+            assert task.args.contains("/c")
+            assert task.args.contains("ember")
+            assert task.args.contains("test")
+            assert task.args.contains("--test-port=-1")
+        } else {
+            assert task.executable.contains("ember")
+            assert task.args.size() == 2
+            assert task.args.contains("test")
+            assert task.args.contains("--test-port=-1")
+        }
     }
 
     @Test


### PR DESCRIPTION
Hi,

I loved how fast & easy your Gradle plugin enables the Emberjs build, but unfortunately it doesn't work on Windows.

When executing external tools like `npm`, `bower` and `ember` you need to use `cmd /c {TOOL} {ARGS}` to successfully run those commands.

It's a bit the fault of Gradle itself, but everyone seems to be using this fix to support Windows when executing external software.

So I had to add conditions to check the OS's Family (Windows in this case) and use `cmd` es executable and add some args to it.

I also changed the tests, so they won't fail on Windows and should work on Unix based systems (Currently don't have access to try this myself)

The resulting JAR works fine with Gradle, so I think you could merge this into the next Release.

Yours,
Daniel

Error Output:

```
17:38:43: Executing external task 'build'...
:backend-web:distTar UP-TO-DATE
:backend-web:npmInstall UP-TO-DATE
:backend-web:bowerInstall UP-TO-DATE
:backend-web:bowerUpdate UP-TO-DATE
:backend-web:test
...
:backend-web:test FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':backend-web:test'.
> A problem occurred starting process 'command 'ember''

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

BUILD FAILED

Total time: 3.186 secs
CreateProcess error=2, Das System kann die angegebene Datei nicht finden
17:38:46: External task execution finished 'build'.
```

Output after fixing the calls:

```
17:42:04: Executing external task 'build'...
:backend-web:distTar UP-TO-DATE
:backend-web:npmInstall UP-TO-DATE
:backend-web:bowerInstall UP-TO-DATE
:backend-web:bowerUpdate UP-TO-DATE
:backend-web:test
...
version: 2.4.1

Running without elevated rights. Running Ember CLI "as Administrator" increases performance significantly.
See www.ember-cli.com/user-guide/#windows for details.

BuildingBuilding.Building..Building...BuildingBuilding.Building..Building...BuildingBuilding.Building..Building...BuildingBuilt project successfully. Stored in "...".
ok 1 PhantomJS 2.1 - JSHint - app.js: should pass jshint

...

1..38
# tests 38
# pass  38
# skip  0
# fail  0

# ok
:backend-web:emberBuild
version: 2.4.1

Running without elevated rights. Running Ember CLI "as Administrator" increases performance significantly.
See www.ember-cli.com/user-guide/#windows for details.

BuildingBuilding.Building..Building...BuildingBuilding.Building..Building...BuildingBuilding.Building..Built project successfully. Stored in "dist/".
:backend-web:distZip
:backend-web:assemble
:backend-web:check UP-TO-DATE
:backend-web:build

BUILD SUCCESSFUL

Total time: 1 mins 8.759 secs
17:43:13: External task execution finished 'build'.
```
