### PR TITLE
Ember CLI 2.7 tests failing because of invalid port

### DIFF
--- a/src/main/groovy/com/kiefer/gradle/EmberCliPlugin.groovy
+++ b/src/main/groovy/com/kiefer/gradle/EmberCliPlugin.groovy
@@ -154,7 +154,7 @@ class EmberCliPlugin implements Plugin<Project> {
                             new FileOutputStream("$reportDirectory/ember-test-results.txt"), System.out);
                 }
 
-                args 'test', '--test-port=-1'
+                args 'test'
             }
 
             project.tasks.create(name: 'emberBuild', type: Exec) {

--- a/src/test/groovy/com/kiefer/gradle/TestTaskTest.groovy
+++ b/src/test/groovy/com/kiefer/gradle/TestTaskTest.groovy
@@ -14,16 +14,14 @@ class TestTaskTest extends EmberCliPluginSupport {
         def task = project.tasks.test
         if(Os.isFamily(Os.FAMILY_WINDOWS)) {
             assert "cmd" == task.executable
-            assert task.args.size() == 4
+            assert task.args.size() == 3
             assert task.args.contains("/c")
             assert task.args.contains("ember")
             assert task.args.contains("test")
-            assert task.args.contains("--test-port=-1")
         } else {
             assert task.executable.contains("ember")
-            assert task.args.size() == 2
+            assert task.args.size() == 1
             assert task.args.contains("test")
-            assert task.args.contains("--test-port=-1")
         }
     }
 


### PR DESCRIPTION
Regarding the newest Ember.JS and CLI versions, the dependencies have changed and using a port less than 0 (in this case `-1`), causes the tests to fail / not even run.

I eliminated the `--test-port=` argument, so tests will run again. I hope this is okay. Tests have also been changed.
